### PR TITLE
changed function for password length prompt variable 

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,6 +26,6 @@ var specialcharacterPrompt = confirm(
 	"Do you want to include special characters in your password?"
 );
 //Here is the password length prompt variable.
-var passwordlengthPrompt = confirm(
+var passwordlengthPrompt = prompt(
 	"Please enter how many characters long would you like your password to be. Min characters allowed= 8 ; Max characters allowed 128."
 );


### PR DESCRIPTION
After testing the password length prompt variable, I noticed that the user does not have the opportunity to enter a number into the pop-up due to the variable being entered with a confirm ( ) instead of prompt ( ) function.

closes #37 